### PR TITLE
hvatanje rezultata testova programabilno, bez default html izlaza

### DIFF
--- a/custom_reporter.js
+++ b/custom_reporter.js
@@ -30,13 +30,15 @@ const myCustomReporter = {
     },
 
     jasmineDone: function(result) {
+        const resultHTMLElement = document.querySelector('#result')
+        let message = ''
         if(this.isFailed) {
-            const resultHTMLElement = document.querySelector('#result')
-            resultHTMLElement.append('Greška! Funkcija nije dobra') 
+            message = 'Greška! Funkcija nije dobra'
         } else {
-            const resultHTMLElement = document.querySelector('#result')
-            resultHTMLElement.append('Zadatak rešen...Dobili ste 3 bambija!')
+            message = 'Zadatak rešen...Dobili ste 3 bambija!'
         }
+        resultHTMLElement.append(message)
+
         console.log('Finished suite');
         console.log(result.overallStatus)
         

--- a/custom_reporter.js
+++ b/custom_reporter.js
@@ -1,0 +1,46 @@
+const myCustomReporter = {
+    isFailed: false,
+
+    jasmineStarted: function(suiteInfo) {
+        console.log('Running suite with ' + suiteInfo.totalSpecsDefined);
+        console.log('Reporting via MyCustomReporter');      
+    },
+
+    suiteStarted: function(result) {
+        console.log('Suite started: ' + result.description + ' whose full description is: ' + result.fullName);     
+    },
+
+    specStarted: function(result) {
+        console.log('Spec started: ' + result.description + ' whose full description is: ' + result.fullName);
+    },
+
+    specDone: function(result) {
+        if(result.status !== 'passed') {
+            this.isFailed = true
+        }
+        console.log('Spec: '
+        + result.description
+        + ' was '
+        + result.status);
+    },
+
+    suiteDone: function(result) {
+        console.log('!!!!!!!!!!!!')
+        console.log(result.failedExpectations) 
+    },
+
+    jasmineDone: function(result) {
+        if(this.isFailed) {
+            const resultHTMLElement = document.querySelector('#result')
+            resultHTMLElement.append('Greška! Funkcija nije dobra') 
+        } else {
+            const resultHTMLElement = document.querySelector('#result')
+            resultHTMLElement.append('Zadatak rešen...Dobili ste 3 bambija!')
+        }
+        console.log('Finished suite');
+        console.log(result.overallStatus)
+        
+    }   
+};
+
+jasmine.getEnv().addReporter(myCustomReporter);

--- a/index.html
+++ b/index.html
@@ -4,12 +4,25 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width">
   <title>Koderski zadaci</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine-html.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/boot.min.js"></script>
+  <script src="custom_reporter.js"></script>
+
+  <style>
+    .jasmine_html-reporter {
+      display:none;
+    }
+  </style>
 </head>
 <body>
   
   <kz-navigacija></kz-navigacija>
   <kz-editor></kz-editor>
+  <div id="result"></div>
   <kz-footer></kz-footer>
   <script src="main.js" type="module"></script>
+  <script src="specs.js" type="module"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,3 +1,11 @@
 import './components/Editor.js'
 import './components/Navigacija.js'
 import './components/Footer.js'
+
+// uhvatiti iz editora
+
+export function findLongestWordLength(text) {
+    const nizBrojeva = text.split(' ')
+      .map(rec => rec.length)
+    return Math.max(...nizBrojeva)
+  }

--- a/specs.js
+++ b/specs.js
@@ -1,0 +1,20 @@
+import { findLongestWordLength } from './main.js'
+
+describe("Find the Longest Word in a String:", function() {
+
+  it("Treba da nadje najduzu rec.", function() {
+    const rezultat = findLongestWordLength('The quick brown fox jumped over the lazy dog')
+    expect(rezultat).toBe(6)
+  })
+
+  it("Treba da nadje najduzu rec.", function() {
+    const rezultat = findLongestWordLength('What is the average airspeed velocity of an unladen swallow')
+    expect(rezultat).toBe(8)
+  })
+
+  it("Treba da nadje najduzu rec.", function() {
+    const rezultat = findLongestWordLength('What if we try a super-long word such as otorhinolaryngology')
+    expect(rezultat).toBe(19)
+  })
+
+})


### PR DESCRIPTION
Malo 'hakovanja' default html izlaza. Nisam znao kako da sprečim izlaz pa sam samo za  jasmine default html element u kome se prikazuje izlaz, stavio css rule 'display:none'...
